### PR TITLE
Always continue all jobs even if other jobs fail

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,7 @@ jobs:
           - php-versions: 5.4
             dependency-levels: 'lowest'
             experimental: false
+      fail-fast: false
     continue-on-error: ${{ matrix.experimental }}
 
     steps:


### PR DESCRIPTION
This will allow contributors to detect problems faster and easier, avoiding scenarios where a problem is corrected only to find that there is a different problem that was not visible in CI logs before on e.g. another PHP version.

See https://github.com/php-fig/log-util/pull/2#discussion_r655343642.